### PR TITLE
Automatically bump version on renovate changes

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -25,4 +25,4 @@ jobs:
           patch="$(echo "$version" | cut -d . -f 3)"
           minor=$((minor + 1))
           patch=0
-          echo -n "$major.$minor.$patch" > version.txt
+          echo -n "$major.$minor.$patch" > VERSION

--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -1,0 +1,28 @@
+name: Bump Version
+
+on:
+  pull_request_target:
+    types: [opened]
+    branches: 'main'
+    paths: 'src/**'
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    if: github.actor == 'renovate[bot]'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Version bump
+      - run: |
+          set -e
+          version="$(cat VERSION)"
+          major="$(echo "$version" | cut -d . -f 1)"
+          minor="$(echo "$version" | cut -d . -f 2)"
+          patch="$(echo "$version" | cut -d . -f 3)"
+          minor=$((minor + 1))
+          patch=0
+          echo -n "$major.$minor.$patch" > version.txt


### PR DESCRIPTION
Renovate seems to be really bad at bumping versions when the version is not in the exact same file and its a well known format. In our case, the version is both in a different file, and its not well-known like a package.json or a pyproject.toml. So lets automatically increment versions on the renovate bot PR.