### PR TITLE
Change span kind from CONSUMER to INTERNAL for github actions

### DIFF
--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell.sh
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell.sh
@@ -340,7 +340,7 @@ _otel_start_script() {
     local name="$GITHUB_WORKFLOW"
     local kind=CONSUMER
     if \[ -n "$GITHUB_JOB" ]; then local name="$name / $GITHUB_JOB"; local kind=CONSUMER; fi
-    if \[ -n "$GITHUB_ACTION" ]; then local name="$name / $GITHUB_ACTION"; local kind=SERVER; fi
+    if \[ -n "$GITHUB_ACTION" ]; then local name="$name / $GITHUB_ACTION"; local kind=INTERNAL; fi
     _root_span_handle="$(otel_span_start "$kind" "$name")"
   elif ! \[ "$OTEL_SHELL_AUTO_INJECTED" = TRUE ] && \[ -z "$OTEL_TRACEPARENT" ]; then
     _root_span_handle="$(otel_span_start SERVER "$(_otel_command_self)")"


### PR DESCRIPTION
Github Workflows and Jobs have pretty names, github actions however have an internal generated name, that shouldnt be treated with too much importance