### PR TITLE
Fix grep that was too liberal

### DIFF
--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell_api.sh
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell_api.sh
@@ -117,7 +117,7 @@ else
 fi
 
 _otel_resolve_package_version() {
-  \dpkg -s "$1" 2> /dev/null | \grep Version: | \cut -d ' ' -f 2
+  \dpkg -s "$1" 2> /dev/null | \grep '^Version: ' | \cut -d ' ' -f 2
 }
 
 otel_span_current() {


### PR DESCRIPTION
Apparently, since recently, there is not just an entry like "Version: 1.2.3" but also maybe an entry like "Config-Version: 1.2.1". that results in a linefeed in the version string, which in turn causes resource attributes to break.