### PR TITLE
Check and fail early if Job name is not "observe"

### DIFF
--- a/actions/instrument/workflow/main.sh
+++ b/actions/instrument/workflow/main.sh
@@ -1,4 +1,5 @@
 set -e
+if [ "$GITHUB_JOB" != observe ]; then echo "Job name must be 'observe'!" >&2; exit 1; fi 
 
 github() {
   url="$GITHUB_API_URL"/"$1"?per_page=100


### PR DESCRIPTION
If using the the workflow step, the job name must be "observe". Otherwise other jobs will not find the shared configuration otherwise. This will result in not properly linked spans and different configuration, super hard to debug. So lets fail early.