### PR TITLE
Handle unusual amount of pipes

### DIFF
--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell.custom.node.js
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell.custom.node.js
@@ -11,6 +11,7 @@ child_process.spawn = function(command, args, options) {
     options = args;
     args = [];
   }
+  if (options && options.stdio && Array.isArray(options.stdio) && options.stdio.length > 3) return _spawn(command, args, options);
   options = options ?? {};
   options.env = options.env ?? { ... process.env };
   options.env['OTEL_SHELL_AUTO_INSTRUMENTATION_HINT'] = command + ' ';
@@ -31,6 +32,7 @@ child_process.exec = function(command, options, callback) {
     callback = options;
     options = {};
   }
+  if (options && options.stdio && Array.isArray(options.stdio) && options.stdio.length > 3) return _exec(command, options, callback);
   if (command.trim().startsWith('/') || command.trim().startsWith('.')) command = 'otel_observe ' + command;
   options = options ?? {};
   options.env = options.env ?? { ... process.env };


### PR DESCRIPTION
Spawning child processes in node allows defining more than the usual three pipes. Injecting via artificial shells means we would need to handle these additional pipes explicitly. Until that logic is place, better not inject into these processes because the pipes would not be there.