### PR TITLE
Instrument dumb-init

### DIFF
--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell.custom.inner.sh
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell.custom.inner.sh
@@ -49,7 +49,7 @@ _otel_alias_prepend watch _otel_inject_inner_command
 _otel_alias_prepend at _otel_inject_inner_command
 _otel_alias_prepend flock _otel_inject_inner_command
 _otel_alias_prepend xargs _otel_inject_inner_command
-_otel_alias_prepeend dumb-init _otel_inject_inner_command
+_otel_alias_prepend dumb-init _otel_inject_inner_command
 
 # sudo apt-get update => sudo sh -c '. /otel.sh; apt-get update' 'sudo'
 

--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell.custom.inner.sh
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell.custom.inner.sh
@@ -49,6 +49,7 @@ _otel_alias_prepend watch _otel_inject_inner_command
 _otel_alias_prepend at _otel_inject_inner_command
 _otel_alias_prepend flock _otel_inject_inner_command
 _otel_alias_prepend xargs _otel_inject_inner_command
+_otel_alias_prepeend dumb-init _otel_inject_inner_command
 
 # sudo apt-get update => sudo sh -c '. /otel.sh; apt-get update' 'sudo'
 


### PR DESCRIPTION
dumb-init is a lightweight starter script / process watchdog for container envs. lets inject so we see whatever is inside