### PR TITLE
Wrong span name for run GitHub action

### DIFF
--- a/actions/instrument/job/decorate_action_run.sh
+++ b/actions/instrument/job/decorate_action_run.sh
@@ -9,6 +9,6 @@ script=". otel.sh
 $script"
 echo "$script" > "$file"
 exit_code=0
-"$@" || exit_code="$?"
+OTEL_SHELL_IS_GITHUB_ACTION_ROOT=TRUE "$@" || exit_code="$?"
 if [ "$exit_code" != 0 ]; then touch /tmp/opentelemetry_shell.github.error; fi
 exit "$exit_code"

--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell.sh
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell.sh
@@ -396,7 +396,8 @@ _otel_start_script() {
     _root_span_handle="$(otel_span_start SERVER "$(\echo "$cmdline" | \cut -d . -f 2- | \cut -d ' ' -f 1)")"
     otel_span_attribute_typed $_root_span_handle string debian.package.name="$(\echo "$cmdline" | \rev | \cut -d / -f 1 | \rev | \cut -d . -f 1)"
     otel_span_attribute_typed $_root_span_handle string debian.package.operation="$(\echo "$cmdline" | \cut -d . -f 2-)"
-  elif \[ "$GITHUB_ACTIONS" = true ] && \[ -n "$GITHUB_RUN_ID" ] && \[ -n "$GITHUB_WORKFLOW" ] && \[ "$PPID" != 0 ] && \[ "$(\cat /proc/$PPID/cmdline | \tr '\000-\037' ' ' | \cut -d ' ' -f 1 | \rev | \cut -d / -f 1 | \rev)" = "Runner.Worker" ]; then
+  elif \[ "$GITHUB_ACTIONS" = true ] && \[ -n "$GITHUB_RUN_ID" ] && \[ -n "$GITHUB_WORKFLOW" ] && ( \[ "$OTEL_SHELL_IS_GITHUB_ACTION_ROOT" = TRUE ] || \[ "$PPID" != 0 ] && \[ "$(\cat /proc/$PPID/cmdline | \tr '\000-\037' ' ' | \cut -d ' ' -f 1 | \rev | \cut -d / -f 1 | \rev)" = "Runner.Worker" ] ); then
+    unset OTEL_SHELL_IS_GITHUB_ACTION_ROOT
     local name="$GITHUB_WORKFLOW"
     local kind=CONSUMER
     if \[ -n "$GITHUB_JOB" ]; then local name="$name / $GITHUB_JOB"; local kind=CONSUMER; fi


### PR DESCRIPTION
Recently, i replaced an exec with a call to child script in decorate_action_run.sh to do proper error detection. However, that had the unwanted sideeffect that the name detection for github actions broke because it relies on checking the commandline of the parent process. and now the parent process is a different one. with this change, we manually transport the information into the child to do proper name detection