### PR TITLE
Fix injection into sudo when suppressing env vars

### DIFF
--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell.custom.inner.sh
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell.custom.inner.sh
@@ -54,7 +54,7 @@ _otel_alias_prepend dumb-init _otel_inject_inner_command
 # sudo apt-get update => sudo sh -c '. /otel.sh; apt-get update' 'sudo'
 
 _otel_inject_sudo() {
-  OTEL_SHELL_INJECT_INNER_COMMAND_MORE_ARGS="--preserve-env=$(\printenv | \grep '^OTEL_' | \cut -d= -f1 | \sort -u | \tr '\n' ','),OTEL_SHELL_COMMANDLINE_OVERRIDE,OTEL_SHELL_COMMANDLINE_OVERRIDE_SIGNATURE,OTEL_SHELL_AUTO_INJECTED" _otel_inject_inner_command "$@"
+  OTEL_SHELL_INJECT_INNER_COMMAND_MORE_ARGS="--preserve-env=$(\printenv | \grep '^OTEL_' | \cut -d= -f1 | \sort -u | \tr '\n' ','),OTEL_SHELL_COMMANDLINE_OVERRIDE,OTEL_SHELL_COMMANDLINE_OVERRIDE_SIGNATURE,OTEL_SHELL_AUTO_INJECTED,TRACEPARENT,TRACESTATE" _otel_inject_inner_command "$@"
 }
 
 _otel_alias_prepend sudo _otel_inject_sudo


### PR DESCRIPTION
env vars are not propagated, and the renaming of env vars has caused traceparent and tracestate not to be propagated anymore