### PR TITLE
Fix infinite recursion on package version resolution error

### DIFF
--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell_api.sh
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell_api.sh
@@ -123,7 +123,7 @@ if \[ "$_otel_shell" = bash ]; then
     local varname="${varname//-/_}"
     if \[ -n "${!varname}" ]; then \echo "${!varname}"; return 0; fi
     \export "$varname=$(_otel_resolve_package_version "$1")"
-    _otel_package_version "$package_name"
+    \echo "$varname"
   }
 else
   _otel_package_version() {


### PR DESCRIPTION
When trying to resolve the version of a debian package (for resource attributes of the executing shell), there are cases where the version cannot be resolved, for example in docker containers where dpkg is not available. in such cases, the function will infinitely loop. lets just return an empty string in that case