### PR TITLE
Handle carriage returns in attribute values

### DIFF
--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell_api.sh
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell_api.sh
@@ -40,11 +40,12 @@ else
     local sdk_output="${OTEL_SHELL_SDK_OUTPUT_REDIRECT:-$sdk_output}"
     \mkfifo "$_otel_remote_sdk_pipe"
     _otel_package_version opentelemetry-shell > /dev/null # to build the cache outside a subshell
+    _otel_package_version "$_otel_shell" > /dev/null
     # several weird things going on in the next line, (1) using '((' fucks up the syntax highlighting in github while '( (' does not, and (2) &> causes weird buffering / late flushing behavior
     if \env --help 2>&1 | \grep -q 'ignore-signal'; then local extra_env_flags='--ignore-signal=INT --ignore-signal=HUP'; fi
     ( (\env $extra_env_flags otelsdk "shell" "$(_otel_package_version opentelemetry-shell)" < "$_otel_remote_sdk_pipe" 1> "$sdk_output" 2> "$sdk_output") &)
     \exec 7> "$_otel_remote_sdk_pipe"
-    _otel_resource_attributes | while IFS= read -r kvp; do _otel_sdk_communicate "RESOURCE_ATTRIBUTE" "auto" "$kvp"; done
+    _otel_resource_attributes
     _otel_sdk_communicate "INIT"
   }
 
@@ -65,42 +66,46 @@ _otel_sdk_communicate() {
 }
 
 _otel_resource_attributes() {
-  \echo telemetry.sdk.name=opentelemetry
-  \echo telemetry.sdk.language=shell
-  \echo -n telemetry.sdk.version=; _otel_package_version opentelemetry-shell
+  _otel_resource_attribute string telemetry.sdk.name=opentelemetry
+  _otel_resource_attribute string telemetry.sdk.language=shell
+  _otel_resource_attribute string telemetry.sdk.version="$(_otel_package_version opentelemetry-shell)"
 
   local process_command="$(_otel_command_self)"
   local process_executable_path="$(\readlink -f "/proc/$$/exe")"
   local process_executable_name="${process_executable_path##*/}" # "$(\printf '%s' "$process_executable_path" | \rev | \cut -d / -f 1 | \rev)"
-  \echo process.pid="$$"
-  \echo process.parent_pid="$PPID"
-  \echo process.executable.name="$process_executable_name"
-  \echo process.executable.path="$process_executable_path"
-  \echo process.command_line="$process_command"
-  \echo process.command="${process_command%% *}" # "$(\printf '%s' "$process_command" | \cut -d ' ' -f 1)"
-  \echo process.owner="$USER"
-  \echo process.runtime.name="$_otel_shell"
+  _otel_resource_attribute int process.pid="$$"
+  _otel_resource_attribute int process.parent_pid="$PPID"
+  _otel_resource_attribute string process.executable.name="$process_executable_name"
+  _otel_resource_attribute string process.executable.path="$process_executable_path"
+  _otel_resource_attribute string process.command_line="$process_command"
+  _otel_resource_attribute string process.command="${process_command%% *}" # "$(\printf '%s' "$process_command" | \cut -d ' ' -f 1)"
+  _otel_resource_attribute string process.owner="$USER"
+  _otel_resource_attribute string process.runtime.name="$_otel_shell"
   case "$_otel_shell" in
-       sh) \echo process.runtime.description="Bourne Shell" ;;
-      ash) \echo process.runtime.description="Almquist Shell" ;;
-     dash) \echo process.runtime.description="Debian Almquist Shell" ;;
-     bash) \echo process.runtime.description="Bourne Again Shell" ;;
-      zsh) \echo process.runtime.description="Z Shell" ;;
-      ksh) \echo process.runtime.description="Korn Shell" ;;
-    pdksh) \echo process.runtime.description="Public Domain Korn Shell" ;;
-     posh) \echo process.runtime.description="Policy-compliant Ordinary Shell" ;;
-     yash) \echo process.runtime.description="Yet Another Shell" ;;
-     bosh) \echo process.runtime.description="Bourne Shell" ;;
-     fish) \echo process.runtime.description="Friendly Interactive Shell" ;;
-     'busybox sh') \echo process.runtime.description="Busy Box" ;;
+       sh) _otel_resource_attribute string process.runtime.description="Bourne Shell" ;;
+      ash) _otel_resource_attribute string process.runtime.description="Almquist Shell" ;;
+     dash) _otel_resource_attribute string process.runtime.description="Debian Almquist Shell" ;;
+     bash) _otel_resource_attribute string process.runtime.description="Bourne Again Shell" ;;
+      zsh) _otel_resource_attribute string process.runtime.description="Z Shell" ;;
+      ksh) _otel_resource_attribute string process.runtime.description="Korn Shell" ;;
+    pdksh) _otel_resource_attribute string process.runtime.description="Public Domain Korn Shell" ;;
+     posh) _otel_resource_attribute string process.runtime.description="Policy-compliant Ordinary Shell" ;;
+     yash) _otel_resource_attribute string process.runtime.description="Yet Another Shell" ;;
+     bosh) _otel_resource_attribute string process.runtime.description="Bourne Shell" ;;
+     fish) _otel_resource_attribute string process.runtime.description="Friendly Interactive Shell" ;;
+     'busybox sh') _otel_resource_attribute austringto process.runtime.description="Busy Box" ;;
   esac
-  \echo -n process.runtime.version=; _otel_package_version "$process_executable_name"
-  \echo process.runtime.options="$-"
+  _otel_resource_attribute string process.runtime.version="$(_otel_package_version "$process_executable_name")"
+  _otel_resource_attribute string process.runtime.options="$-"
 
-  \echo service.name="${OTEL_SERVICE_NAME:-unknown_service}"
-  \echo service.version="$OTEL_SERVICE_VERSION"
-  \echo service.namespace="$OTEL_SERVICE_NAMESPACE"
-  \echo service.instance.id="$OTEL_SERVICE_INSTANCE_ID"
+  _otel_resource_attribute string service.name="${OTEL_SERVICE_NAME:-unknown_service}"
+  _otel_resource_attribute string service.version="$OTEL_SERVICE_VERSION"
+  _otel_resource_attribute string service.namespace="$OTEL_SERVICE_NAMESPACE"
+  _otel_resource_attribute string service.instance.id="$OTEL_SERVICE_INSTANCE_ID"
+}
+
+_otel_resource_attribute() {
+  _otel_sdk_communicate RESOURCE_ATTRIBUTE "$@"
 }
 
 _otel_command_self() {

--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell_api.sh
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell_api.sh
@@ -93,7 +93,7 @@ _otel_resource_attributes() {
      yash) _otel_resource_attribute string process.runtime.description="Yet Another Shell" ;;
      bosh) _otel_resource_attribute string process.runtime.description="Bourne Shell" ;;
      fish) _otel_resource_attribute string process.runtime.description="Friendly Interactive Shell" ;;
-     'busybox sh') _otel_resource_attribute austringto process.runtime.description="Busy Box" ;;
+     'busybox sh') _otel_resource_attribute string process.runtime.description="Busy Box" ;;
   esac
   _otel_resource_attribute string process.runtime.version="$(_otel_package_version "$process_executable_name")"
   _otel_resource_attribute string process.runtime.options="$-"

--- a/tests/sdk/test_sdk_span_attribute.shell
+++ b/tests/sdk/test_sdk_span_attribute.shell
@@ -8,6 +8,7 @@ otel_span_attribute $span_id key=value
 assert_equals 0 $?
 otel_span_attribute $span_id foo='bar
 baz'
+otel_span_attribute $span_id bar='printf "\r\n\r\n"'
 assert_equals 0 $?
 otel_span_end $span_id
 assert_equals 0 $?
@@ -20,3 +21,4 @@ assert_equals "null" $(echo "$span" | jq -r '.parent_id')
 assert_equals "UNSET" $(echo "$span" | jq -r '.status.status_code')
 assert_equals "value" $(echo "$span" | jq -r '.attributes.key')
 assert_equals "bar baz" "$(echo "$span" | jq -r '.attributes.foo')"
+assert_equals 'printf "\r\n\r\n"' "$(echo "$span" | jq -r '.attributes.bar')"

--- a/tests/sdk/test_sdk_span_attribute.shell
+++ b/tests/sdk/test_sdk_span_attribute.shell
@@ -8,7 +8,6 @@ otel_span_attribute $span_id key=value
 assert_equals 0 $?
 otel_span_attribute $span_id foo='bar
 baz'
-otel_span_attribute $span_id bar='printf "\r\n\r\n"'
 assert_equals 0 $?
 otel_span_end $span_id
 assert_equals 0 $?
@@ -21,4 +20,3 @@ assert_equals "null" $(echo "$span" | jq -r '.parent_id')
 assert_equals "UNSET" $(echo "$span" | jq -r '.status.status_code')
 assert_equals "value" $(echo "$span" | jq -r '.attributes.key')
 assert_equals "bar baz" "$(echo "$span" | jq -r '.attributes.foo')"
-assert_equals 'printf "\r\n\r\n"' "$(echo "$span" | jq -r '.attributes.bar')"


### PR DESCRIPTION
printing resource attribtues and then looping over and feeding them into the SDK doesnt work as intended when there are special control characters like carriage returns. lets make the calls directly