### PR TITLE
Fix process.commandline resource attribute for non-std fds

### DIFF
--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell.sh
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell.sh
@@ -310,6 +310,8 @@ _otel_instrument_and_source() {
 _otel_inject_and_exec_directly() { # this function assumes there is no fd fuckery
   if \[ "$#" = 1 ]; then
     export OTEL_SHELL_CONSERVATIVE_EXEC=TRUE
+    export OTEL_SHELL_AUTO_INJECTED=TRUE
+    # in theory we could also use _otel_commandline_override to reset some overrides
     \eval '"exec"' "$(\xargs -0 sh -c '. otelapi.sh; _otel_escape_args "$@"' sh < /proc/$$/cmdline)"
   fi
   

--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell.sh
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell.sh
@@ -310,8 +310,10 @@ _otel_instrument_and_source() {
 _otel_inject_and_exec_directly() { # this function assumes there is no fd fuckery
   if \[ "$#" = 1 ]; then
     export OTEL_SHELL_CONSERVATIVE_EXEC=TRUE
-    export OTEL_SHELL_AUTO_INJECTED=TRUE
-    # in theory we could also use _otel_commandline_override to reset some overrides
+    if \[ -n "$_otel_commandline_override" ]; then
+      export OTEL_SHELL_COMMANDLINE_OVERRIDE="$_otel_commandline_override"
+      export OTEL_SHELL_COMMANDLINE_OVERRIDE_SIGNATURE="$PPID"
+    fi
     \eval '"exec"' "$(\xargs -0 sh -c '. otelapi.sh; _otel_escape_args "$@"' sh < /proc/$$/cmdline)"
   fi
   

--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell.sh
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell.sh
@@ -310,6 +310,7 @@ _otel_instrument_and_source() {
 _otel_inject_and_exec_directly() { # this function assumes there is no fd fuckery
   if \[ "$#" = 1 ]; then
     export OTEL_SHELL_CONSERVATIVE_EXEC=TRUE
+    _otel_sdk_communicate 'SPAN_AUTO_END'
     if \[ -n "$_otel_commandline_override" ]; then
       export OTEL_SHELL_COMMANDLINE_OVERRIDE="$_otel_commandline_override"
       export OTEL_SHELL_COMMANDLINE_OVERRIDE_SIGNATURE="$PPID"


### PR DESCRIPTION
When encountering things like "exec 3> /foo" which is not technically exec but just opening a fouth non-std fd, we actually have to do an exec and fall back to a more conservative implementation for exec cmonitoring. we do that because its rather unusual. however, in such a case, technically, the same process gets a new commandline, and that new commandline, when override by its parent, loses that override. so we need to reconstruct that override before doing the exec