### PR TITLE
Fix GitHub job error detection

### DIFF
--- a/actions/instrument/job/action.yaml
+++ b/actions/instrument/job/action.yaml
@@ -5,3 +5,7 @@ runs:
   pre: 'inject_and_init.js'
   main: 'nop.js'
   post: 'shutdown.js'
+inputs:
+  __job_status:
+    description: 'INTERNAL ONLY - DO NOT SET MANUALLY'
+    default: '${{ job.status }}'

--- a/actions/instrument/job/inject_and_init.sh
+++ b/actions/instrument/job/inject_and_init.sh
@@ -8,7 +8,7 @@ github() {
     | grep 'rel="last"' | cut -d ';' -f1 | cut -d '?' -f 2- | tr '&' '\n' \
     | grep '^page=' | cut -d = -f 2 \
     | xargs seq 1 | while IFS= read -r page; do
-      command curl --no-progress-meter --fail --retry 12 --retry-all-errors "$url"\&page="$page"
+      curl --no-progress-meter --fail --retry 12 --retry-all-errors "$url"\&page="$page"
     done
 }
 export -f github

--- a/actions/instrument/job/inject_and_init.sh
+++ b/actions/instrument/job/inject_and_init.sh
@@ -72,7 +72,7 @@ if [ -z "$OTEL_SERVICE_NAME" ]; then
 fi
 
 root4job_end() {
-  if [ -f /tmp/opentelemetry_shell.github.error ] || [ "$(github_workflow jobs | jq -r ".jobs[] | select(.name == \"$GITHUB_JOB\") | select(.run_attempt == $GITHUB_RUN_ATTEMPT) | .steps[] | select(.status == \"completed\") | select(.conclusion == \"failure\") | .name" | wc -l)" -gt 0 ]; then
+  if [ -f /tmp/opentelemetry_shell.github.error ]; then
     otel_span_error "$span_handle"
   fi
   otel_span_end "$span_handle"

--- a/actions/instrument/job/inject_and_init.sh
+++ b/actions/instrument/job/inject_and_init.sh
@@ -8,7 +8,7 @@ github() {
     | grep 'rel="last"' | cut -d ';' -f1 | cut -d '?' -f 2- | tr '&' '\n' \
     | grep '^page=' | cut -d = -f 2 \
     | xargs seq 1 | while IFS= read -r page; do
-      curl --no-progress-meter --fail --retry 12 --retry-all-errors "$url"\&page="$page"
+      curl --no-progress-meter --fail --retry 16 --retry-all-errors "$url"\&page="$page"
     done
 }
 export -f github

--- a/actions/instrument/job/shutdown.sh
+++ b/actions/instrument/job/shutdown.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
 set -e
+if [ "$OTEL_SHELL_GITHUB_JOB_FAILED" = TRUE ]; then
+  touch /tmp/opentelemetry_shell.github.error
+fi
 root_pid="$STATE_pid"
 kill -USR1 "$root_pid"
 while kill -0 "$root_pid" 2> /dev/null; do sleep 1; done

--- a/actions/instrument/job/shutdown.sh
+++ b/actions/instrument/job/shutdown.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-if [ "$OTEL_SHELL_GITHUB_JOB_FAILED" = TRUE ]; then
+if [ "$INPUT___JOB_STATUS" = 'failed' ]; then
   touch /tmp/opentelemetry_shell.github.error
 fi
 root_pid="$STATE_pid"

--- a/actions/instrument/job/shutdown.sh
+++ b/actions/instrument/job/shutdown.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-if [ "$INPUT___JOB_STATUS" = 'failed' ]; then
+if [ "$INPUT___JOB_STATUS" = failure ]; then
   touch /tmp/opentelemetry_shell.github.error
 fi
 root_pid="$STATE_pid"


### PR DESCRIPTION
This is really a nop-fix. Just by having complete coverage of all types of actions (node, shell, docker) this already works properly. Querying the API is a fallback only.