### PR TITLE
Fix shebang injeciton with whitespaces in shebang

### DIFF
--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell.sh
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell.sh
@@ -207,7 +207,11 @@ _otel_resolve_shebang() {
   if \[ -z "$path" ] || ! \[ -x "$path" ]; then return 1; fi
   read -r first_line < "$path"
   if ! _otel_string_starts_with "$first_line" "#!"; then return 2; fi
-  \echo "${first_line#"#!"}"
+  local shebang="${first_line#"#!"}"
+  while _otel_string_starts_with "$shebang" " "; do
+    local shebang="${first_line#" "}"
+  done
+  \echo "$shebang"
 }
 
 _otel_dealiasify() {

--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell.sh
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell.sh
@@ -207,10 +207,8 @@ _otel_resolve_shebang() {
   if \[ -z "$path" ] || ! \[ -x "$path" ]; then return 1; fi
   read -r first_line < "$path"
   if ! _otel_string_starts_with "$first_line" "#!"; then return 2; fi
-  local shebang="${first_line#"#!"}"
-  while _otel_string_starts_with "$shebang" " "; do
-    local shebang="${first_line#" "}"
-  done
+  local shebang="${first_line#\#!}"
+  local shebang="${shebang#"${shebang%%[![:space:]]*}"}"
   \echo "$shebang"
 }
 


### PR DESCRIPTION
until now we have only observed shebangs like `#!/bin/sh`. However, if there is a whitespace `#! /bin/sh`, we fail to inject properly