### PR TITLE
Fix renovate injection

### DIFF
--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell.custom.renovate.sh
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell.custom.renovate.sh
@@ -1,6 +1,7 @@
 #!/bin/false
 
 if _otel_string_contains "$(_otel_resolve_command_self)" /usr/local/bin/renovate || _otel_string_contains "$(_otel_resolve_command_self)" /usr/local/sbin/renovate; then # renovate looks at some very specific env vars to enable tracing
+  export OTEL_SHELL_CONFIG_INJECT_DEEP=TRUE
   export OTEL_SHELL_CONFIG_INSTRUMENT_ABSOLUTE_PATHS=TRUE
   if _otel_string_contains "$OTEL_TRACES_EXPORTER" console; then export RENOVATE_TRACING_CONSOLE_EXPORTER=true; fi
   if \[ -z "$OTEL_EXPORTER_OTLP_ENDPOINT" ] && ( _otel_string_contains "$OTEL_TRACES_EXPORTER" otlp || \[ -z "$OTEL_TRACES_EXPORTER" ] ); then


### PR DESCRIPTION
Renovate docker container uses node.js internally, we need to auto-enable deep injection to link the internal instrumentation properly