### PR TITLE
Fix printf instrumentation

### DIFF
--- a/src/usr/share/opentelemetry_shell/opentelemetry_shell.sh
+++ b/src/usr/share/opentelemetry_shell/opentelemetry_shell.sh
@@ -131,6 +131,7 @@ _otel_list_aliased_commands() {
 }
 
 _otel_list_builtin_commands() {
+  \echo printf
   \echo type
   \echo printenv
   \echo cd


### PR DESCRIPTION
printf is a builtin, but it was missing from the builtin lists. it was working most of the time, because on many machines printf is ALSO an external executable, causing it to be instrumented. by listing it explicitly, it will also be insturmented on systems where its just a builtin and not an external executable.