### PR TITLE
Fix demo generation

### DIFF
--- a/.github/workflows/autorerun.yaml
+++ b/.github/workflows/autorerun.yaml
@@ -2,7 +2,7 @@ name: Autorerun
 
 on:
   workflow_run:
-    workflows: [ 'Test', 'Publish' ]
+    workflows: [ 'Test', 'Publish', 'Refresh Demos' ]
     types: completed
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/refresh_demos.yaml
+++ b/.github/workflows/refresh_demos.yaml
@@ -73,7 +73,7 @@ jobs:
           sudo docker start collector
           sleep 10
           cat meta.json | jq -r .setup | (grep -v '^null$' || true) | sh
-          bash -e demo.sh 1> output.stdout 2> output.stderr || true
+          bash -e demo.sh 1> output.stdout 2> output.stderr
           sleep 15
           sudo docker stop collector
           rm config.yaml


### PR DESCRIPTION
sometimes the http://example.com doesnt respond, in which case the demo fails and doesnt generate a pretty trace. abort the workflow in such a case, and retry