### PR TITLE
Improve GitHub export span time resolution

### DIFF
--- a/actions/instrument/workflow/main.sh
+++ b/actions/instrument/workflow/main.sh
@@ -137,7 +137,7 @@ done | sed 's/\t/ /g' | while read -r TRACEPARENT step_number step_conclusion st
   fi
   if [ -r "$times_dir"/"$TRACEPARENT" ]; then
     previus_step_completed_at="$(cat "$times_dir"/"$TRACEPARENT")"
-    if [ "$previus_step_completed_at" > "$step_started_at" ]; then "$step_started_at"="$previous_step_completed_at"; fi
+    if [ "$previus_step_completed_at" > "$step_started_at" ]; then step_started_at="$previous_step_completed_at"; fi
     if [ "$step_started_at" > "$step_completed_at" ]; then step_completed_at="$step_started_at"; fi
   fi
   

--- a/actions/instrument/workflow/main.sh
+++ b/actions/instrument/workflow/main.sh
@@ -60,7 +60,7 @@ otel_counter_observe "$workflow_run_counter_handle" "$observation_handle"
 link="${GITHUB_SERVER_URL:-https://github.com}"/"$(jq < "$workflow_json" -r .repository.owner.login)"/"$(jq < "$workflow_json" -r .repository.name)"/actions/runs/"$(jq < "$workflow_json" -r .id)"
 workflow_started_at="$(jq < "$workflow_json" -r .run_started_at)"
 workflow_ended_at="$(jq < "$jobs_json" -r .completed_at | sort -r | head -n 1)"
-if [ "$(ls "$logs_dir" | grep -v -- '^'"$logs_dir"/- | wc -l)" -gt 0 ]; then
+if [ "$(ls "$logs_dir"/*.txt | grep -v -- '^'"$logs_dir"/- | wc -l)" -gt 0 ]; then
   last_log_timestamp="$(cat "$logs_dir"/*.txt | cut -d ' ' -f 1 | sort -r | head -n 1)"
   if [ "$last_log_timestamp" > "$workflow_ended_at" ]; then workflow_ended_at="$last_log_timestamp"; fi
 fi

--- a/actions/instrument/workflow/main.sh
+++ b/actions/instrument/workflow/main.sh
@@ -137,7 +137,7 @@ done | sed 's/\t/ /g' | while read -r TRACEPARENT step_number step_conclusion st
   fi
   if [ -r "$times_dir"/"$TRACEPARENT" ]; then
     previus_step_completed_at="$(cat "$times_dir"/"$TRACEPARENT")"
-    if [ "$previus_step_completed_at" > "$step_started_at" ]; then "$step_started_at" = "$previous_step_completed_at"; fi
+    if [ "$previus_step_completed_at" > "$step_started_at" ]; then "$step_started_at"="$previous_step_completed_at"; fi
     if [ "$step_started_at" > "$step_completed_at" ]; then step_completed_at="$step_started_at"; fi
   fi
   

--- a/actions/instrument/workflow/main.sh
+++ b/actions/instrument/workflow/main.sh
@@ -1,3 +1,4 @@
+export OTEL_SHELL_SDK_OUTPUT_REDIRECT=/dev/stderr
 #/bin/bash
 set -e
 . ../shared/config_validation.sh

--- a/actions/instrument/workflow/main.sh
+++ b/actions/instrument/workflow/main.sh
@@ -64,7 +64,7 @@ link="${GITHUB_SERVER_URL:-https://github.com}"/"$(jq < "$workflow_json" -r .rep
 workflow_started_at="$(jq < "$workflow_json" -r .run_started_at)"
 workflow_ended_at="$(jq < "$jobs_json" -r .completed_at | sort -r | head -n 1)"
 if [ "$(ls "$logs_dir"/*/*.txt | wc -l)" -gt 0 ]; then
-  last_log_timestamp="$(tail -n 1 "$logs_dir"/*/*.txt | cut -d ' ' -f 1 | sort | tail -n 1)"
+  last_log_timestamp="$(tail -q -n 1 "$logs_dir"/*/*.txt | cut -d ' ' -f 1 | sort | tail -n 1)"
   if [ "$last_log_timestamp" > "$workflow_ended_at" ]; then workflow_ended_at="$last_log_timestamp"; fi
 fi
 workflow_span_handle="$(otel_span_start @"$workflow_started_at" CONSUMER "$(jq < "$workflow_json" -r .name)")"
@@ -137,8 +137,8 @@ done | sed 's/\t/ /g' | while read -r TRACEPARENT step_number step_conclusion st
     if [ -n "$last_log_timestamp" ] && [ "$last_log_timestamp" > "$step_completed_at" ]; then step_completed_at="$last_log_timestamp"; fi
   fi
   if [ -r "$times_dir"/"$TRACEPARENT" ]; then
-    previus_step_completed_at="$(cat "$times_dir"/"$TRACEPARENT")"
-    if [ "$previus_step_completed_at" > "$step_started_at" ]; then step_started_at="$previous_step_completed_at"; fi
+    previous_step_completed_at="$(cat "$times_dir"/"$TRACEPARENT")"
+    if [ "$previous_step_completed_at" > "$step_started_at" ]; then step_started_at="$previous_step_completed_at"; fi
     if [ "$step_started_at" > "$step_completed_at" ]; then step_completed_at="$step_started_at"; fi
   fi
   

--- a/actions/instrument/workflow/main.sh
+++ b/actions/instrument/workflow/main.sh
@@ -63,7 +63,7 @@ link="${GITHUB_SERVER_URL:-https://github.com}"/"$(jq < "$workflow_json" -r .rep
 workflow_started_at="$(jq < "$workflow_json" -r .run_started_at)"
 workflow_ended_at="$(jq < "$jobs_json" -r .completed_at | sort -r | head -n 1)"
 if [ "$(ls "$logs_dir"/*/*.txt | wc -l)" -gt 0 ]; then
-  last_log_timestamp="$(cat "$logs_dir"/*/*.txt | cut -d ' ' -f 1 | sort -r | head -n 1)"
+  last_log_timestamp="$(tail -n 1 "$logs_dir"/*/*.txt | cut -d ' ' -f 1 | sort | tail -n 1)"
   if [ "$last_log_timestamp" > "$workflow_ended_at" ]; then workflow_ended_at="$last_log_timestamp"; fi
 fi
 workflow_span_handle="$(otel_span_start @"$workflow_started_at" CONSUMER "$(jq < "$workflow_json" -r .name)")"


### PR DESCRIPTION
start and end times of workflows, jobs, and steps are at second resolution only. this casues very weird effects, because logs have nanosecond resolutions and are outside the start/end times, and several sequential steps, may have same start/end times even. we use logs to adjust times