### PR TITLE
Collect github logs from stdout

### DIFF
--- a/actions/instrument/job/decorate_action.sh
+++ b/actions/instrument/job/decorate_action.sh
@@ -29,7 +29,7 @@ otel_span_attribute_typed $span_handle string github.actions.action.ref="$GITHUB
 [ -z "${_OTEL_GITHUB_STEP_ACTION_PHASE:-}" ] || otel_span_attribute_typed $span_handle string github.actions.action.phase="$_OTEL_GITHUB_STEP_ACTION_PHASE"
 otel_span_activate "$span_handle"
 exit_code_file="$(mktemp)"
-{ otel_observe "$_OTEL_GITHUB_STEP_AGENT_INJECTION_FUNCTION" "$@"; echo "$?" > "$exit_code_file" } | while read -r line; do
+{ otel_observe "$_OTEL_GITHUB_STEP_AGENT_INJECTION_FUNCTION" "$@"; echo "$?" > "$exit_code_file"; } | while read -r line; do
   if _otel_string_starts_with "$line" ':: '; then
     _otel_log_record "$TRACEPARENT" auto "$line"
   fi

--- a/actions/instrument/job/decorate_action.sh
+++ b/actions/instrument/job/decorate_action.sh
@@ -28,8 +28,14 @@ otel_span_attribute_typed $span_handle string github.actions.action.name="$GITHU
 otel_span_attribute_typed $span_handle string github.actions.action.ref="$GITHUB_ACTION_REF"
 [ -z "${_OTEL_GITHUB_STEP_ACTION_PHASE:-}" ] || otel_span_attribute_typed $span_handle string github.actions.action.phase="$_OTEL_GITHUB_STEP_ACTION_PHASE"
 otel_span_activate "$span_handle"
-otel_observe "$_OTEL_GITHUB_STEP_AGENT_INJECTION_FUNCTION" "$@"
-exit_code="$?"
+exit_code_file="$(mktemp)"
+{ otel_observe "$_OTEL_GITHUB_STEP_AGENT_INJECTION_FUNCTION" "$@"; echo "$?" > "$exit_code_file" } | while read -r line; do
+  if _otel_string_starts_with "$line" ':: '; then
+    _otel_log_record "$TRACEPARENT" auto "$line"
+  fi
+  echo "$line"
+done
+exit_code="$(cat "$exit_code_file")"
 otel_span_deactivate "$span_handle"
 printenv -0 | tr '\n' ' ' | tr '\0' '\n' | cut -d '=' -f 1 | grep '^STATE_' | while read -r key; do otel_span_attribute_typed $span_handle string github.actions.step.state.after."$(variable_name_2_attribute_key "${key#STATE_}")"="$(variable_name_2_attribute_value "$key")"; done
 cat "$GITHUB_STATE" | while read -r kvp; do otel_span_attribute_typed $span_handle string github.actions.step.state.after."$(variable_name_2_attribute_key "${kvp%%=*}")"="${kvp#*=}"; done


### PR DESCRIPTION
Github Actions use a special syntax for logs (called github action commands) to log to stdout on job level. Only on step level, we should record these lines as logs as well. 