### PR TITLE
Update dependency @actions/cache to v5.0.2 (#2778)

### DIFF
--- a/actions/instrument/job/package-lock.json
+++ b/actions/instrument/job/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@actions/artifact": "5.0.1",
-        "@actions/cache": "5.0.1"
+        "@actions/cache": "5.0.2"
       }
     },
     "node_modules/@actions/artifact": {
@@ -31,15 +31,15 @@
       }
     },
     "node_modules/@actions/cache": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-5.0.1.tgz",
-      "integrity": "sha512-c+oH047Z2zmXLhjMZfEKjxZfv6Ou7T0sn5fhz6yupICXm5OOR47oZn5zxNO8MP7ttkxv5TOg3WsMrffri5Xhfw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-5.0.2.tgz",
+      "integrity": "sha512-6w3i9n12eWJyut6TOnh7SIxGmeIepB5wbXMvlPv9+6CjvTD4OYKi1Wjh7TQrjEf8xLb6hxsVCpPsL/1gxnlTtw==",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.0",
         "@actions/exec": "^2.0.0",
         "@actions/glob": "^0.5.0",
-        "@actions/http-client": "^3.0.0",
+        "@actions/http-client": "^3.0.1",
         "@actions/io": "^2.0.0",
         "@azure/abort-controller": "^1.1.0",
         "@azure/core-rest-pipeline": "^1.22.0",
@@ -138,9 +138,9 @@
       "license": "MIT"
     },
     "node_modules/@actions/http-client": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.0.tgz",
-      "integrity": "sha512-1s3tXAfVMSz9a4ZEBkXXRQD4QhY3+GAsWSbaYpeknPOKEeyRiU3lH+bHiLMZdo2x/fIeQ/hscL1wCkDLVM2DZQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.1.tgz",
+      "integrity": "sha512-SbGS8c/vySbNO3kjFgSW77n83C4MQx/Yoe+b1hAdpuvfHxnkHzDq2pWljUpAA56Si1Gae/7zjeZsV0CYjmLo/w==",
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",

--- a/actions/instrument/job/package.json
+++ b/actions/instrument/job/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@actions/cache": "5.0.1",
+    "@actions/cache": "5.0.2",
     "@actions/artifact": "5.0.1"
   }
 }


### PR DESCRIPTION
Automated backport of commit cce09a0e1b72ae24deeebad236ab8f0530c11bb1