### PR TITLE
Update alpine Docker tag to v3.23.3 (#2849)

### DIFF
--- a/actions/instrument/workflow/Dockerfile
+++ b/actions/instrument/workflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.2
+FROM alpine:3.23.3
 ARG repository
 LABEL org.opencontainers.image.source=https://github.com/$repository
 COPY ./package.apk /root/package.apk


### PR DESCRIPTION
Automated backport of commit 78a6d006d88c7c894e0afa61750e433761c3404a