### PR TITLE
Fix `telemetry.sdk.version` showing "shell" instead of version number on Alpine (#3122)

### DIFF
--- a/src/usr/share/opentelemetry_shell/api.sh
+++ b/src/usr/share/opentelemetry_shell/api.sh
@@ -163,7 +163,7 @@ else
 fi
 
 _otel_resolve_package_version() {
-  (\dpkg -s "$1" || \rpm -qi "$1" || \apk version "$1" | \tail -n 1 | \cut -d - -f 2 | { \echo -n 'Version: '; \cat; }) 2> /dev/null | \grep Version | \cut -d : -f 2 | tr -d ' ' || \true
+  (\dpkg -s "$1" || \rpm -qi "$1" || \apk version "$1" | \tail -n 1 | \cut -d ' ' -f 3 | \cut -d - -f 1 | { \echo -n 'Version: '; \cat; }) 2> /dev/null | \grep Version | \cut -d : -f 2 | tr -d ' ' || \true
 }
 
 otel_span_current() {


### PR DESCRIPTION
Automated backport of commit 8b69e76119d77c82d626cfd6ce38a0e56a9b7e7d