### PR TITLE
Fix job-level instrumentation showing wrapper bash path as span name (#3290)

### DIFF
--- a/actions/instrument/job/decorate_action_run.sh
+++ b/actions/instrument/job/decorate_action_run.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 if [ "$(cat /tmp/opentelemetry_shell_action_name 2> /dev/null)" = "$GITHUB_ACTION" ]; then exec "$@"; fi
+unset OTEL_SHELL_COMMAND_OVERRIDE
 _OTEL_GITHUB_STEP_AGENT_INSTRUMENTATION_FILE=/usr/share/opentelemetry_shell/agent.instrumentation.shells.sh
 _OTEL_GITHUB_STEP_AGENT_INJECTION_FUNCTION=_otel_inject_shell_with_copy
 _OTEL_GITHUB_STEP_ACTION_TYPE=shell


### PR DESCRIPTION
Automated backport of commit f07d2a4733883a1d645208070d970aa46ce7bb5f