### PR TITLE
Update dependency net.bytebuddy:byte-buddy to v1.18.8-jdk5 (#3279)

### DIFF
--- a/src/usr/share/opentelemetry_shell/agent.instrumentation.java/pom.xml
+++ b/src/usr/share/opentelemetry_shell/agent.instrumentation.java/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.18.7-jdk5</version>
+      <version>1.18.8-jdk5</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Automated backport of commit 64f948eaceb1b30a43d69273cb7f8b38fd442785