### PR TITLE
Update dependency io.opentelemetry.javaagent:opentelemetry-javaagent to v2.26.1 (#3270)

### DIFF
--- a/src/usr/share/opentelemetry_shell/agent.instrumentation.java/pom.xml
+++ b/src/usr/share/opentelemetry_shell/agent.instrumentation.java/pom.xml
@@ -10,7 +10,7 @@
     <dependency>
       <groupId>io.opentelemetry.javaagent</groupId>
       <artifactId>opentelemetry-javaagent</artifactId>
-      <version>2.26.0</version>
+      <version>2.26.1</version>
     </dependency>
     <dependency>
       <groupId>net.bytebuddy</groupId>


### PR DESCRIPTION
Automated backport of commit 4ba9aa76e399b7079f62b44a79420efa5c391af2