### PR TITLE
Fix Fedora manual-install CI failures by removing `rev` dependency from installer fallback (#3450)

### DIFF
--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -13,6 +13,20 @@ else
 fi
 
 package="$(mktemp -u)"."$extension"
+extract_release_version() {
+  while IFS= read -r location_header; do
+    case "$location_header" in
+      *"location: "*"/releases/tag/v"*)
+        location_header="${location_header##*location: }"
+        location_header="${location_header##*/releases/tag/v}"
+        case "$location_header" in
+          */*|'') ;;
+          *) echo "$location_header";;
+        esac
+        ;;
+    esac
+  done
+}
 curl -L --no-progress-meter https://api.github.com/repos/plengauer/opentelemetry-shell/releases/latest | jq '.assets[] | select(.name | endswith("'"$extension"'"))' | jq -s | case "$extension" in
     deb) jq 'if . | any(.name | endswith("_all.deb")) then .[] | select(.name | endswith("_'"$(arch | sed s/x86_64/amd64/g | sed s/aarch64/arm64/g | sed 's/le$/el/g')"'.deb")) else .[0] end';;
     rpm) jq 'if . | any(.name | endswith(".noarch.rpm")) then .[] | select(.name | endswith("_'"$(arch)"'.rpm")) else .[0] end';;
@@ -21,7 +35,7 @@ curl -L --no-progress-meter https://api.github.com/repos/plengauer/opentelemetry
   esac | jq .browser_download_url -r | xargs -r wget -O "$package"
 if ! [ -r "$package" ]; then
   echo "Warning: failed to use API, falling back to downloading directly." >&2
-  curl -v --no-progress-meter https://github.com/plengauer/Thoth/releases/latest 2>&1 | grep location | tr -d '\r' | rev | cut -d / -f 1 | rev | cut -d v -f 2 | case "$extension" in
+  curl -v --no-progress-meter https://github.com/plengauer/Thoth/releases/latest 2>&1 | grep location | tr -d '\r' | extract_release_version | case "$extension" in
       deb) xargs -I '{}' echo -n opentelemetry-shell_'{}'_"$(arch | sed s/x86_64/amd64/g | sed s/aarch64/arm64/g | sed 's/le$/el/g')".deb;;
       rpm) xargs -I '{}' echo -n opentelemetry-shell-'{}'-1."$(arch)".rpm;;
       apk) xargs -I '{}' echo -n opentelemetry-shell-'{}'-r0.apk;;
@@ -30,7 +44,7 @@ if ! [ -r "$package" ]; then
 fi
 if ! [ -r "$package" ]; then
   echo "Warning: failed to use API and failed to directly download architecture-dependent package, falling back to downloading architecture-independent package directly." >&2
-  curl -v --no-progress-meter https://github.com/plengauer/Thoth/releases/latest 2>&1 | grep location | tr -d '\r' | rev | cut -d / -f 1 | rev | cut -d v -f 2 | case "$extension" in
+  curl -v --no-progress-meter https://github.com/plengauer/Thoth/releases/latest 2>&1 | grep location | tr -d '\r' | extract_release_version | case "$extension" in
       deb) xargs -I '{}' echo -n opentelemetry-shell_'{}'_all.deb;;
       rpm) xargs -I '{}' echo -n opentelemetry-shell-'{}'-1.noarch.rpm;;
       apk) xargs -I '{}' echo -n opentelemetry-shell-'{}'-r0.apk;;
@@ -39,7 +53,7 @@ if ! [ -r "$package" ]; then
 fi
 if ! [ -r "$package" ]; then
   echo "Warning: failed to use API and failed to directly download any package, falling back to old releases format." >&2
-  curl -v --no-progress-meter https://github.com/plengauer/Thoth/releases/latest 2>&1 | grep location | tr -d '\r' | rev | cut -d / -f 1 | rev | cut -d v -f 2 | xargs -I '{}' echo -n opentelemetry-shell_'{}'."$extension" | xargs -r -I '{}' wget -O "$package" https://github.com/plengauer/Thoth/releases/latest/download/'{}'
+  curl -v --no-progress-meter https://github.com/plengauer/Thoth/releases/latest 2>&1 | grep location | tr -d '\r' | extract_release_version | xargs -I '{}' echo -n opentelemetry-shell_'{}'."$extension" | xargs -r -I '{}' wget -O "$package" https://github.com/plengauer/Thoth/releases/latest/download/'{}'
 fi
 if ! [ -r "$package" ]; then
   echo "Error: failed download package." >&2

--- a/tests/unit/test_unit_install_extract_release_version.sh
+++ b/tests/unit/test_unit_install_extract_release_version.sh
@@ -1,0 +1,9 @@
+. ./assert.sh
+
+line="$(printf '*   Trying 140.82.121.4:443...< location: https://github.com/plengauer/Thoth/releases/tag/v1.2.3\r')"
+version="$(printf '%s\n' "$line" | grep location | tr -d '\r' | while IFS= read -r read_line; do case "$read_line" in *"location: "*"/releases/tag/v"*) read_line="${read_line##*location: }"; read_line="${read_line##*/releases/tag/v}"; case "$read_line" in */*|'') ;; *) echo "$read_line";; esac;; esac; done)"
+invalid_line="$(printf '*   Trying 140.82.121.4:443...< location: https://github.com/plengauer/Thoth/releases/tag/v1.2.3/path\r')"
+invalid_version="$(printf '%s\n' "$invalid_line" | grep location | tr -d '\r' | while IFS= read -r read_line; do case "$read_line" in *"location: "*"/releases/tag/v"*) read_line="${read_line##*location: }"; read_line="${read_line##*/releases/tag/v}"; case "$read_line" in */*|'') ;; *) echo "$read_line";; esac;; esac; done)"
+
+assert_equals "1.2.3" "$version"
+assert_equals "" "$invalid_version"


### PR DESCRIPTION
Automated backport of commit bc5711cc1824ce107b036f922119e10e430c20ef