### PR TITLE
Update otel/opentelemetry-collector-contrib Docker tag to v0.152.1 (#3477)

### DIFF
--- a/actions/instrument/job/Dockerfile
+++ b/actions/instrument/job/Dockerfile
@@ -1,2 +1,2 @@
-FROM otel/opentelemetry-collector-contrib:0.152.0
+FROM otel/opentelemetry-collector-contrib:0.152.1
 # WARNING this is just for renovate to update the version. it is not built directly


### PR DESCRIPTION
Automated backport of commit eca155a6661866a5fe5d92fba8c4d815747d5ba7