### PR TITLE
Fix autobackport release branch creation for major tag aliases (#3533)

### DIFF
--- a/.github/workflows/autobackport.yml
+++ b/.github/workflows/autobackport.yml
@@ -75,14 +75,26 @@ jobs:
         run: |
           set -e
           current_tag=$(git describe --tags --abbrev=0 ${{ matrix.ref }})
-          [ -n "$current_tag" ] || exit 1
+          if [ -z "${current_tag:-}" ]; then exit 1; fi
+          current_tag_sha=$(git rev-list -n 1 "$current_tag")
+          while read -r tag; do
+            if [ "${#tag}" -gt "${#current_tag}" ]; then
+              current_tag="$tag"
+            fi
+          done < <(git tag --points-at "$current_tag_sha")
+          case "$current_tag" in
+            v*.*.*) current_tag="${current_tag%.*}";;
+            v*.*) ;;
+            v*) exit 2;;
+            *) exit 3;;
+          esac
           branch_name="release/$current_tag"
           echo name="$branch_name" >> "$GITHUB_OUTPUT"
           if git ls-remote --exit-code --heads origin "$branch_name"; then
             git fetch origin "$branch_name"
             git checkout "$branch_name"
           else
-            git checkout -b "$branch_name" "${current_tag}.0"
+            git checkout -b "$branch_name" "$current_tag".0
             git push -u origin "$branch_name"
           fi
       


### PR DESCRIPTION
Automated backport of commit a8c3bc02d6ecbca67229a24b83caff6355814bef