### PR TITLE
Update GitHub Actions test workflows to cover pinned and latest macOS and Windows runners (#3550)

### DIFF
--- a/.github/workflows/test_github.yml
+++ b/.github/workflows/test_github.yml
@@ -726,8 +726,11 @@ jobs:
       - run: echo hello world
   job-windows:
     needs: job-smoke
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    strategy:
+      matrix:
+        runner: [windows-2022, windows-latest]
     permissions:
       contents: read
       actions: read
@@ -744,8 +747,11 @@ jobs:
       - run: echo hello world
   job-macos:
     needs: job-smoke
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    strategy:
+      matrix:
+        runner: [macos-15, macos-latest]
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/test_shell.yml
+++ b/.github/workflows/test_shell.yml
@@ -335,10 +335,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   windows-shell:
     needs: [list-shells, smoke]
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 180
     strategy:
       matrix:
+        runner: [windows-2022, windows-latest]
         version: [1, 2]
         shell: ${{ fromJSON(needs.list-shells.outputs.shells) }}
       fail-fast: false


### PR DESCRIPTION
Automated backport of commit 3800d041ff3b1b2b56d7363a41f3d6c93de32428