### PR TITLE
Update dependency net.bytebuddy:byte-buddy to v1.18.11-jdk5 (#3705)

### DIFF
--- a/src/usr/share/opentelemetry_shell/agent.instrumentation.java/pom.xml
+++ b/src/usr/share/opentelemetry_shell/agent.instrumentation.java/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.18.10-jdk5</version>
+      <version>1.18.11-jdk5</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Automated backport of commit 1f9acdb42415dad8d0f59cc926315d90312007cf