### PR TITLE
Fix `sudo --` injection: place `--preserve-env` before end-of-options separator (#3739)

### DIFF
--- a/src/usr/share/opentelemetry_shell/agent.instrumentation.inner.sh
+++ b/src/usr/share/opentelemetry_shell/agent.instrumentation.inner.sh
@@ -16,7 +16,10 @@ _otel_inject_inner_command_args() {
   shift
   # options
   # -option or not executable file 
-  while \[ "$#" -gt 0 ] && ( _otel_string_starts_with "$1" - || ! ( \[ -x "$1" ] || \[ -x "$(\which "$1" 2> /dev/null)" ] ) || ( \[ -x "$1" ] && _otel_string_starts_with "$(_otel_resolve_shebang "${1##*/}")" "$command " ) ); do \echo -n " "; _otel_escape_arg "$1"; shift; done
+  while \[ "$#" -gt 0 ] && ( _otel_string_starts_with "$1" - || ! ( \[ -x "$1" ] || \[ -x "$(\which "$1" 2> /dev/null)" ] ) || ( \[ -x "$1" ] && _otel_string_starts_with "$(_otel_resolve_shebang "${1##*/}")" "$command " ) ); do
+    if \[ "$1" = -- ]; then shift; break; fi
+    \echo -n " "; _otel_escape_arg "$1"; shift
+  done
   # opt out if there is no command
   if \[ -z "$*" ]; then return 0; fi
   # more options

--- a/tests/auto/test_auto_injection_sudo.sh
+++ b/tests/auto/test_auto_injection_sudo.sh
@@ -10,6 +10,13 @@ span="$(resolve_span '.name == "echo hello world"')"
 assert_equals "SpanKind.INTERNAL" "$(\echo "$span" | jq -r '.kind')"
 assert_equals "sudo echo hello world" "$(\echo "$span" | jq -r '.resource.attributes."process.command_line"')"
 
+sudo -- echo hello world
+assert_equals 0 $?
+span="$(resolve_span '.name == "sudo -- echo hello world"')"
+assert_equals "SpanKind.INTERNAL" "$(\echo "$span" | jq -r '.kind')"
+span="$(resolve_span '.name == "echo hello world") | select(.resource.attributes."process.command_line" == "sudo -- echo hello world"')"
+assert_equals "SpanKind.INTERNAL" "$(\echo "$span" | jq -r '.kind')"
+
 # security policy doesnt allow this
 # sudo -D / echo hello world 1
 # assert_equals 0 $?


### PR DESCRIPTION
Automated backport of commit ae22ae423ab5ed896b212b5f9ca9eded226a282c