### PR TITLE
fix: use `rm -f` in `otel_shutdown` to handle missing FIFO gracefully (#3896)

### DIFF
--- a/src/usr/share/opentelemetry_shell/api.sh
+++ b/src/usr/share/opentelemetry_shell/api.sh
@@ -64,7 +64,7 @@ else
 
   otel_shutdown() {
     \eval "\\exec ${_otel_remote_sdk_fd}>&-"
-    \rm "$_otel_remote_sdk_pipe"
+    \rm -f "$_otel_remote_sdk_pipe"
   }
 fi
 


### PR DESCRIPTION
Automated backport of commit 2fd59f8af031cf7a6dbbb8a5ab25448bdbe44ae2